### PR TITLE
Configure CI workflows and add PolliLib test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,114 @@
+name: Main Branch Delivery
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Upload Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  report-build-status:
+    name: Report Build Status
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Report Build Status
+        run: node tools/report-build-status.mjs
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    needs: build
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Tests
+        run: npm test
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-branch-test-results
+          path: reports/test-results.json
+          if-no-files-found: warn
+
+  deploy:
+    name: Deploy to Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ needs.build.result == 'success' }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  report-tests:
+    name: Report Tests Statuses
+    runs-on: ubuntu-latest
+    needs: tests
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download test report
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: main-branch-test-results
+          path: reports
+
+      - name: Report Tests Statuses
+        run: node tools/report-tests.mjs --title "Main Branch Test Results" --results reports/test-results.json

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,57 @@
+name: Pull Request Quality Checks
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+jobs:
+  run-tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Tests
+        run: npm test
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pull-request-test-results
+          path: reports/test-results.json
+          if-no-files-found: warn
+
+  report-tests:
+    name: Report Tests Statuses
+    runs-on: ubuntu-latest
+    needs: run-tests
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download test report
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: pull-request-test-results
+          path: reports
+
+      - name: Report Tests Statuses
+        run: node tools/report-tests.mjs --title "Pull Request Test Results" --results reports/test-results.json

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,9 @@ dist
 # Docusaurus cache and generated files
 .docusaurus
 
+# Test reports
+reports/
+
 # Serverless directories
 .serverless/
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Static browser demo for interacting with [Pollinations](https://pollinations.ai)
 [PolliLib](./Libs/pollilib/) client. The application is built with Vite so it can be deployed to a
 static host such as GitHub Pages. It features:
 
+## Main branch status
+
+[![Build status](https://github.com/Unity-Lab-AI/chatdemo/actions/workflows/main.yml/badge.svg?branch=main&job=Build%20and%20Upload%20Artifacts)](https://github.com/Unity-Lab-AI/chatdemo/actions/workflows/main.yml)
+[![Test status](https://github.com/Unity-Lab-AI/chatdemo/actions/workflows/main.yml/badge.svg?branch=main&job=Run%20Tests)](https://github.com/Unity-Lab-AI/chatdemo/actions/workflows/main.yml)
+
 - Text chat powered by PolliLib's `chat()` helper.
 - Assistant-guided and manual (`/image`) Pollinations image generation.
 - Model selector populated from the Pollinations text model catalog.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node tools/run-tests.mjs"
   },
   "repository": {
     "type": "git",

--- a/tests/pollilib-text.test.mjs
+++ b/tests/pollilib-text.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { PolliClient, text } from '../Libs/pollilib/index.js';
+
+export const name = 'PolliLib text() generates a response';
+
+function createMockResponse(body) {
+  if (typeof Response === 'function') {
+    return new Response(body, { status: 200 });
+  }
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    async text() {
+      return body;
+    },
+    headers: new Map(),
+  };
+}
+
+export async function run() {
+  const requests = [];
+  const fakeFetch = async (url, init) => {
+    requests.push({ url: String(url), init: { ...(init ?? {}) } });
+    return createMockResponse('Hello from Pollinations!');
+  };
+
+  const client = new PolliClient({
+    fetch: fakeFetch,
+    auth: { mode: 'referrer', referrer: 'https://github.com/Unity-Lab-AI/chatdemo' },
+    timeoutMs: 5_000,
+  });
+
+  const prompt = 'Say hello to Pollinations';
+  const response = await text(prompt, { model: 'webgpt', temperature: 0.7 }, client);
+
+  assert.equal(response, 'Hello from Pollinations!');
+  assert.equal(requests.length, 1, 'Expected the mock fetch to be invoked once');
+  assert.ok(requests[0].url.includes(encodeURIComponent(prompt)), 'The request URL should include the encoded prompt');
+  assert.equal(requests[0].init.method, 'GET');
+}

--- a/tools/report-build-status.mjs
+++ b/tools/report-build-status.mjs
@@ -1,0 +1,28 @@
+import fs from 'node:fs/promises';
+
+function formatStatus(value) {
+  if (!value) return 'UNKNOWN';
+  return String(value).toUpperCase();
+}
+
+async function main() {
+  const result = formatStatus(process.env.BUILD_RESULT ?? 'unknown');
+  const summaryLines = [
+    '# Build Status',
+    '',
+    `* Build job conclusion: **${result}**`,
+  ];
+  const summary = `${summaryLines.join('\n')}\n`;
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    await fs.appendFile(summaryPath, summary, 'utf8');
+  }
+  console.log(summary);
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error('[report-build-status] Unable to report build status.');
+  console.error(error);
+}

--- a/tools/report-tests.mjs
+++ b/tools/report-tests.mjs
@@ -1,0 +1,78 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function parseArgs(argv) {
+  const args = { resultsPath: path.resolve(__dirname, '../reports/test-results.json'), title: 'Test Results' };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if ((arg === '--results' || arg === '--file') && argv[i + 1]) {
+      args.resultsPath = path.resolve(argv[++i]);
+    } else if (arg === '--title' && argv[i + 1]) {
+      args.title = argv[++i];
+    }
+  }
+  return args;
+}
+
+function formatStatus(status) {
+  if (!status) return 'UNKNOWN';
+  return status.toUpperCase();
+}
+
+async function readResults(filePath) {
+  const raw = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function buildSummaryMarkdown({ title, data }) {
+  const { overallStatus = 'unknown', summary = {}, tests = [] } = data;
+  let md = `# ${title}\n\n`;
+  md += `* Overall status: **${formatStatus(overallStatus)}**\n`;
+  const total = summary.total ?? tests.length ?? 0;
+  const passed = summary.passed ?? tests.filter(test => test.status === 'passed').length;
+  const failed = summary.failed ?? tests.filter(test => test.status === 'failed').length;
+  md += `* Total tests: ${total}\n`;
+  md += `* Passed: ${passed}\n`;
+  md += `* Failed: ${failed}\n\n`;
+
+  if (tests.length) {
+    md += '| Test | Status | Duration (ms) | Details |\n';
+    md += '| --- | --- | --- | --- |\n';
+    for (const test of tests) {
+      const status = formatStatus(test.status);
+      const duration = Number.isFinite(test.durationMs) ? test.durationMs : '—';
+      const details = test.error ? `<details><summary>View</summary>\n\n\`${test.error.replace(/`/gu, '\\`')}\`\n\n</details>` : '';
+      md += `| ${test.name} | ${status} | ${duration} | ${details} |\n`;
+    }
+  } else {
+    md += '_No test entries were found in the report._\n';
+  }
+
+  return md;
+}
+
+async function writeSummary(summary) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    await fs.appendFile(summaryPath, `${summary}\n`, 'utf8');
+  }
+  console.log(summary);
+}
+
+async function main() {
+  try {
+    const args = parseArgs(process.argv);
+    const data = await readResults(args.resultsPath);
+    const summary = buildSummaryMarkdown({ title: args.title, data });
+    await writeSummary(summary);
+  } catch (error) {
+    console.error('[report-tests] Unable to summarize test results.');
+    console.error(error);
+  }
+}
+
+await main();

--- a/tools/run-tests.mjs
+++ b/tools/run-tests.mjs
@@ -1,0 +1,101 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const defaultOutput = path.resolve(__dirname, '../reports/test-results.json');
+
+function parseArgs(argv) {
+  const args = { output: defaultOutput, pattern: /.*/ };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--output' && argv[i + 1]) {
+      args.output = path.resolve(argv[++i]);
+    } else if (arg === '--pattern' && argv[i + 1]) {
+      args.pattern = new RegExp(argv[++i]);
+    }
+  }
+  return args;
+}
+
+async function discoverTests(pattern) {
+  const testsDir = path.resolve(__dirname, '../tests');
+  const entries = await fs.readdir(testsDir, { withFileTypes: true });
+  return entries
+    .filter(entry => entry.isFile() && /\.test\.mjs$/u.test(entry.name) && pattern.test(entry.name))
+    .map(entry => ({
+      file: path.join(testsDir, entry.name),
+      name: entry.name,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function loadTestModule(filePath) {
+  const module = await import(pathToFileURL(filePath).href);
+  const name = module.name ?? module.testName ?? path.parse(filePath).name;
+  const fn = module.run ?? module.default;
+  if (typeof fn !== 'function') {
+    throw new Error(`Test module ${filePath} does not export a runnable function`);
+  }
+  return { name, run: fn };
+}
+
+async function runTests({ output, pattern }) {
+  const tests = await discoverTests(pattern);
+  if (!tests.length) {
+    console.warn('[run-tests] No test files matched the provided criteria.');
+  }
+  const results = [];
+  let failed = 0;
+  for (const test of tests) {
+    const entry = { file: test.file, status: 'skipped', name: test.name };
+    const start = Date.now();
+    try {
+      const { name, run } = await loadTestModule(test.file);
+      entry.name = name;
+      await run();
+      entry.status = 'passed';
+    } catch (error) {
+      failed += 1;
+      entry.status = 'failed';
+      entry.error = error?.stack ?? error?.message ?? String(error);
+    } finally {
+      entry.durationMs = Date.now() - start;
+      results.push(entry);
+      const status = entry.status.toUpperCase();
+      console.log(`[run-tests] ${status} ${entry.name} (${entry.durationMs} ms)`);
+      if (entry.error) {
+        console.log(entry.error);
+      }
+    }
+  }
+
+  const summary = {
+    total: results.length,
+    passed: results.filter(result => result.status === 'passed').length,
+    failed,
+  };
+  const overallStatus = failed > 0 ? 'failed' : 'passed';
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    overallStatus,
+    summary,
+    tests: results,
+  };
+
+  await fs.mkdir(path.dirname(output), { recursive: true });
+  await fs.writeFile(output, JSON.stringify(payload, null, 2), 'utf8');
+
+  console.log(`[run-tests] Completed ${summary.total} test(s). Passed: ${summary.passed}. Failed: ${summary.failed}.`);
+  console.log(`[run-tests] Results written to ${output}.`);
+}
+
+try {
+  const args = parseArgs(process.argv);
+  await runTests(args);
+} catch (error) {
+  console.error('[run-tests] Unexpected error while running tests.');
+  console.error(error);
+}


### PR DESCRIPTION
## Summary
- add a pull request workflow that runs the PolliLib-based tests and records their results without blocking merges
- configure the main-branch workflow to build artifacts, deploy to GitHub Pages, run tests, and publish build/test summaries
- provide a mock-backed PolliLib text test plus supporting scripts and README badges for monitoring main-branch status

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9a826e234832f835802066367d7a0