### PR TITLE
Add Pollinations image flags for private enhanced no-logo requests

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -510,6 +510,9 @@ async function generateImageAsset(prompt, { width, height, model: imageModel } =
         width,
         height,
         model: imageModel,
+        nologo: true,
+        private: true,
+        enhance: true,
       },
       client,
     );


### PR DESCRIPTION
## Summary
- ensure chat image generation calls request Pollinations images without logos and with private/enhanced flags

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9b267637c832f80dec935753e397d