### PR TITLE
Support PolliLib seed chat endpoint

### DIFF
--- a/Libs/pollilib/src/text.js
+++ b/Libs/pollilib/src/text.js
@@ -81,6 +81,25 @@ export async function chat({
     throw new Error('chat() requires a non-empty messages array');
   }
   const targetEndpoint = resolveChatEndpoint(endpoint);
+  if (targetEndpoint === 'seed') {
+    return await performSeedChat(
+      {
+        model,
+        messages,
+        seed,
+        temperature,
+        top_p,
+        presence_penalty,
+        frequency_penalty,
+        max_tokens,
+        private: priv,
+        response_format,
+        timeoutMs,
+        stream,
+      },
+      client,
+    );
+  }
   const url = `${client.textBase}/${encodeURIComponent(targetEndpoint)}`;
   const body = { model, messages };
   if (seed != null) body.seed = seed;
@@ -141,4 +160,151 @@ function resolveChatEndpoint(endpoint) {
   }
   value = value.replace(/^\/+/u, '').replace(/\/+$/u, '').toLowerCase();
   return value || 'openai';
+}
+
+async function performSeedChat(
+  {
+    model,
+    messages,
+    seed,
+    temperature,
+    top_p,
+    presence_penalty,
+    frequency_penalty,
+    max_tokens,
+    private: priv,
+    response_format,
+    timeoutMs,
+    stream,
+  },
+  client,
+) {
+  if (stream) {
+    throw new Error('Seed endpoint currently does not support streaming responses.');
+  }
+  const prompt = buildSeedPrompt(messages);
+  const url = `${client.textBase}/${encodeURIComponent(prompt)}`;
+  const params = {};
+  if (model) params.model = model;
+  if (seed != null) params.seed = seed;
+  if (temperature != null) params.temperature = temperature;
+  if (top_p != null) params.top_p = top_p;
+  if (presence_penalty != null) params.presence_penalty = presence_penalty;
+  if (frequency_penalty != null) params.frequency_penalty = frequency_penalty;
+  if (max_tokens != null) params.max_tokens = max_tokens;
+  if (priv != null) params.private = boolString(priv);
+
+  let expectJson = false;
+  if (response_format) {
+    if (response_format === 'json_object') {
+      expectJson = true;
+    } else if (
+      typeof response_format === 'object' &&
+      response_format !== null &&
+      response_format.type === 'json_object'
+    ) {
+      expectJson = true;
+    }
+  }
+  if (expectJson) params.json = 'true';
+
+  const response = await client.get(url, { params, timeoutMs });
+  await raiseForStatus(response, 'chat(seed)');
+  let bodyText = await response.text();
+  if (!expectJson) {
+    bodyText = bodyText ?? '';
+  }
+
+  const created = Math.floor(Date.now() / 1000);
+  const completionId = `pllns_${created.toString(36)}${Math.random().toString(36).slice(2)}`;
+  return {
+    id: completionId,
+    object: 'chat.completion',
+    created,
+    model: model ?? 'seed',
+    choices: [
+      {
+        index: 0,
+        finish_reason: 'stop',
+        message: {
+          role: 'assistant',
+          content: expectJson ? bodyText : String(bodyText ?? ''),
+        },
+      },
+    ],
+  };
+}
+
+function buildSeedPrompt(messages) {
+  const safeMessages = Array.isArray(messages) ? messages : [];
+  if (!safeMessages.length) {
+    throw new Error('chat(seed) requires at least one message.');
+  }
+  const lines = [];
+  for (const message of safeMessages) {
+    const roleLabel = describeRole(message?.role, message?.name);
+    const parts = [];
+    const content = extractChatContent(message?.content);
+    if (content) parts.push(content);
+    if (Array.isArray(message?.tool_calls) && message.tool_calls.length) {
+      for (const call of message.tool_calls) {
+        const description = formatToolCall(call);
+        if (description) parts.push(description);
+      }
+    }
+    lines.push(parts.length ? `${roleLabel}: ${parts.join('\n')}` : `${roleLabel}:`);
+  }
+  lines.push('Assistant:');
+  return lines.join('\n\n');
+}
+
+function describeRole(role, name) {
+  if (!role) return 'Message';
+  const normalized = String(role).trim().toLowerCase();
+  switch (normalized) {
+    case 'system':
+      return 'System';
+    case 'user':
+      return name ? `User (${name})` : 'User';
+    case 'assistant':
+      return 'Assistant';
+    case 'tool':
+      return name ? `Tool (${name})` : 'Tool';
+    default:
+      return normalized ? normalized[0].toUpperCase() + normalized.slice(1) : 'Message';
+  }
+}
+
+function extractChatContent(content) {
+  if (content == null) return '';
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map(entry => {
+        if (!entry) return '';
+        if (typeof entry === 'string') return entry;
+        if (typeof entry === 'object') {
+          if (entry.text != null) return String(entry.text);
+          if (entry.content != null) return String(entry.content);
+          if (entry.type === 'text' && entry.value != null) return String(entry.value);
+        }
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+  if (typeof content === 'object') {
+    if (content.text != null) return String(content.text);
+    if (content.content != null) return String(content.content);
+  }
+  return String(content);
+}
+
+function formatToolCall(call) {
+  if (!call) return '';
+  try {
+    return `Tool call: ${JSON.stringify(call)}`;
+  } catch {
+    return 'Tool call: [unserializable]';
+  }
 }

--- a/tests/pollilib-seed-chat.test.mjs
+++ b/tests/pollilib-seed-chat.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { PolliClient, chat } from '../Libs/pollilib/index.js';
+
+export const name = 'PolliLib chat() flattens conversations for the seed endpoint';
+
+export async function run() {
+  const requests = [];
+  const fakeFetch = async (url, init) => {
+    const entry = { url: String(url), init: { ...(init ?? {}) } };
+    requests.push(entry);
+    return new Response('Unity says hi!', {
+      status: 200,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  };
+
+  const client = new PolliClient({ fetch: fakeFetch, textBase: 'https://text.pollinations.ai' });
+
+  const messages = [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: 'Hello there!' },
+  ];
+
+  const result = await chat({ model: 'unity', endpoint: 'seed', messages, temperature: 0.2 }, client);
+
+  assert.equal(result.model, 'unity');
+  assert.equal(result.choices[0].message.role, 'assistant');
+  assert.equal(result.choices[0].message.content, 'Unity says hi!');
+
+  assert.equal(requests.length, 1, 'Expected exactly one seed request');
+  const request = requests[0];
+  assert.equal(request.init.method, 'GET');
+
+  const url = new URL(request.url);
+  assert.equal(url.searchParams.get('model'), 'unity');
+  assert.equal(url.searchParams.get('temperature'), '0.2');
+
+  const prompt = decodeURIComponent(url.pathname.slice(1));
+  assert(prompt.includes('System: You are a helpful assistant.'), 'Prompt should include the system message');
+  assert(prompt.includes('User: Hello there!'), 'Prompt should include the user content');
+  assert(prompt.trim().endsWith('Assistant:'), 'Prompt should end with an assistant cue');
+}


### PR DESCRIPTION
## Summary
- teach `chat()` to route seed endpoints through a Pollinations text request and keep OpenAI-compatible responses
- update existing chat endpoint test and add new coverage for the seed conversation flattener

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9bf55ce90832f86ddc7c3609a7708