### PR TITLE
Add runtime Pollinations token support

### DIFF
--- a/.github/functions/polli-token.js
+++ b/.github/functions/polli-token.js
@@ -1,0 +1,22 @@
+export async function onRequest(context) {
+  const token = context?.env?.POLLI_TOKEN ?? context?.env?.VITE_POLLI_TOKEN ?? null;
+  if (!token) {
+    return new Response(JSON.stringify({ error: 'Pollinations token is not configured.' }), {
+      status: 404,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store, no-cache, must-revalidate',
+        'X-Robots-Tag': 'noindex',
+      },
+    });
+  }
+
+  return new Response(JSON.stringify({ token }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store, no-cache, must-revalidate',
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+}

--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ npm run build
 
 The generated assets are written to `dist/` and can be published as-is. When hosted on GitHub Pages
 make sure the contents of `dist/` are deployed.
+
+## Configuring the Pollinations token
+
+Pollinations models that require tiered access need a token on every request. The application now
+expects the token to be provided at runtime so it is never bundled into the static assets.
+
+- **GitHub Pages / production** – Provide the `POLLI_TOKEN` secret in the repository (or Pages
+  environment). The included Pages Function at `.github/functions/polli-token.js` exposes the token
+  at runtime via `/api/polli-token`, and responses are marked as non-cacheable.
+- **Local development** – Either define `POLLI_TOKEN`/`VITE_POLLI_TOKEN` in your shell when running
+  `npm run dev`, add a `<meta name="pollinations-token" ...>` tag to `index.html`, or inject
+  `window.__POLLINATIONS_TOKEN__` before the application bootstraps.
+
+If the token cannot be resolved the UI remains disabled and an error is shown in the status banner.

--- a/src/pollinations-client.js
+++ b/src/pollinations-client.js
@@ -1,0 +1,215 @@
+import { PolliClient } from '../Libs/pollilib/index.js';
+
+let tokenPromise = null;
+let cachedToken = null;
+let cachedSource = null;
+
+export async function createPollinationsClient({ referrer } = {}) {
+  const { token, source } = await ensureToken();
+  const getToken = async () => token;
+  const client = new PolliClient({
+    auth: {
+      mode: 'token',
+      placement: 'query',
+      getToken,
+      referrer: referrer ?? inferReferrer(),
+    },
+  });
+  return { client, tokenSource: source };
+}
+
+async function ensureToken() {
+  if (cachedToken) {
+    return { token: cachedToken, source: cachedSource };
+  }
+  if (!tokenPromise) {
+    tokenPromise = resolveToken();
+  }
+  const result = await tokenPromise;
+  cachedToken = result.token;
+  cachedSource = result.source;
+  return result;
+}
+
+async function resolveToken() {
+  const attempts = [fetchTokenFromApi, readTokenFromMeta, readTokenFromWindow, readTokenFromEnv];
+  const errors = [];
+
+  for (const attempt of attempts) {
+    try {
+      const result = await attempt();
+      if (result?.token) {
+        return {
+          token: result.token,
+          source: result.source ?? attempt.name ?? 'unknown',
+        };
+      }
+      if (result?.error) {
+        errors.push({ source: result.source ?? attempt.name ?? 'unknown', error: result.error });
+      }
+    } catch (error) {
+      errors.push({ source: attempt.name ?? 'unknown', error });
+    }
+  }
+
+  const messages = errors
+    .map(entry => formatError(entry.source, entry.error))
+    .filter(Boolean);
+  const message =
+    messages.length > 0
+      ? `Unable to load Pollinations token. Attempts: ${messages.join('; ')}`
+      : 'Unable to load Pollinations token.';
+  const failure = new Error(message);
+  failure.causes = errors;
+  throw failure;
+}
+
+async function fetchTokenFromApi() {
+  if (typeof fetch !== 'function') {
+    return { token: null, source: 'api', error: new Error('Fetch is unavailable in this environment.') };
+  }
+  try {
+    const response = await fetch('/api/polli-token', {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+    if (response.status === 404) {
+      return { token: null, source: 'api', error: new Error('Token endpoint not found (404).') };
+    }
+    if (!response.ok) {
+      return {
+        token: null,
+        source: 'api',
+        error: new Error(`Token endpoint responded with HTTP ${response.status}`),
+      };
+    }
+    const contentType = response.headers?.get?.('content-type') ?? '';
+    let body;
+    if (contentType.includes('application/json')) {
+      body = await response.json();
+    } else {
+      body = await response.text();
+    }
+    const token = extractTokenValue(body);
+    if (token) {
+      return { token, source: 'api' };
+    }
+    return { token: null, source: 'api', error: new Error('Token endpoint returned no token.') };
+  } catch (error) {
+    return { token: null, source: 'api', error };
+  }
+}
+
+function readTokenFromMeta() {
+  if (typeof document === 'undefined') {
+    return { token: null, source: 'meta', error: new Error('Document is unavailable.') };
+  }
+  const meta = document.querySelector('meta[name="pollinations-token"]');
+  if (!meta) {
+    return { token: null, source: 'meta' };
+  }
+  const content = meta.getAttribute('content');
+  const token = extractTokenValue(content);
+  if (!token) {
+    return { token: null, source: 'meta' };
+  }
+  try {
+    meta.setAttribute('content', '');
+  } catch {
+    // ignore inability to reset the meta tag
+  }
+  return { token, source: 'meta' };
+}
+
+function readTokenFromWindow() {
+  if (typeof window === 'undefined') {
+    return { token: null, source: 'window', error: new Error('Window is unavailable.') };
+  }
+  const candidate = window.__POLLINATIONS_TOKEN__ ?? window.POLLI_TOKEN ?? null;
+  const token = extractTokenValue(candidate);
+  if (!token) {
+    return { token: null, source: 'window' };
+  }
+  try {
+    delete window.__POLLINATIONS_TOKEN__;
+  } catch {
+    // ignore cleanup errors
+  }
+  try {
+    delete window.POLLI_TOKEN;
+  } catch {
+    // ignore cleanup errors
+  }
+  return { token, source: 'window' };
+}
+
+function readTokenFromEnv() {
+  if (!import.meta?.env?.DEV) {
+    return { token: null, source: 'env' };
+  }
+  const env = import.meta.env ?? {};
+  const candidate =
+    env.VITE_POLLI_TOKEN ??
+    env.POLLI_TOKEN ??
+    env.VITE_POLLINATIONS_TOKEN ??
+    env.POLLINATIONS_TOKEN ??
+    null;
+  const token = extractTokenValue(candidate);
+  if (!token) {
+    return { token: null, source: 'env' };
+  }
+  return { token, source: 'env' };
+}
+
+function extractTokenValue(value) {
+  if (value == null) return null;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if ((trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'))) {
+      try {
+        return extractTokenValue(JSON.parse(trimmed));
+      } catch {
+        // ignore JSON parse errors and fall back to the raw string
+      }
+    }
+    return trimmed;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const extracted = extractTokenValue(entry);
+      if (extracted) return extracted;
+    }
+    return null;
+  }
+  if (typeof value === 'object') {
+    for (const key of ['token', 'value', 'secret', 'apiKey', 'key']) {
+      if (key in value) {
+        const extracted = extractTokenValue(value[key]);
+        if (extracted) return extracted;
+      }
+    }
+  }
+  return null;
+}
+
+function formatError(source, error) {
+  if (!error) return null;
+  const reason = error?.message ?? String(error);
+  return source ? `${source}: ${reason}` : reason;
+}
+
+function inferReferrer() {
+  try {
+    if (typeof window !== 'undefined' && window.location?.origin) {
+      return window.location.origin;
+    }
+    if (typeof document !== 'undefined' && document.location?.origin) {
+      return document.location.origin;
+    }
+  } catch {
+    // ignore errors when attempting to access location
+  }
+  return null;
+}

--- a/tests/pollilib-token-query.test.mjs
+++ b/tests/pollilib-token-query.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { PolliClient, chat } from '../Libs/pollilib/index.js';
+
+export const name = 'PolliLib seed chat requests include query tokens';
+
+function createResponse(body) {
+  if (typeof Response === 'function') {
+    return new Response(body, { status: 200 });
+  }
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    async text() {
+      return body;
+    },
+    headers: new Map(),
+  };
+}
+
+export async function run() {
+  const requests = [];
+  const fakeFetch = async (url, init = {}) => {
+    requests.push({ url: String(url), init: { ...init } });
+    const method = init.method ?? 'GET';
+    if (method === 'GET') {
+      return createResponse('Unity says hi!');
+    }
+    return createResponse('');
+  };
+
+  const client = new PolliClient({
+    fetch: fakeFetch,
+    auth: { mode: 'token', token: 'example-token' },
+    timeoutMs: 1_000,
+  });
+
+  const messages = [{ role: 'user', content: 'Say hello' }];
+  const result = await chat({ model: 'unity', endpoint: 'seed', messages }, client);
+
+  assert.equal(result.model, 'unity');
+  assert.equal(result.choices?.[0]?.message?.content, 'Unity says hi!');
+  assert.equal(requests.length, 1, 'Expected a single request to be issued.');
+  const [request] = requests;
+  assert.equal(request.init.method, 'GET');
+  const requestUrl = new URL(request.url);
+  assert.equal(requestUrl.searchParams.get('token'), 'example-token');
+  const authHeader = request.init.headers?.Authorization ?? request.init.headers?.authorization;
+  assert.equal(authHeader, 'Bearer example-token');
+}


### PR DESCRIPTION
## Summary
- expose the Pollinations token at runtime via a Pages Function and document the configuration
- update the PolliLib client to always include the token in query parameters and cover the unity seed flow
- bootstrap the UI with an async token-aware client, gating the controls until authentication is ready

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c9ce76f86c832fb17ac03e50ed10a4