### PR TITLE
Fix Pollinations token env resolution

### DIFF
--- a/.github/functions/polli-token.js
+++ b/.github/functions/polli-token.js
@@ -1,5 +1,25 @@
+function readTokenFromEnvironment(context) {
+  const envSources = [];
+  if (context?.env) envSources.push(context.env);
+  if (typeof process !== 'undefined' && process?.env) envSources.push(process.env);
+
+  for (const env of envSources) {
+    const candidate =
+      env?.POLLI_TOKEN ??
+      env?.VITE_POLLI_TOKEN ??
+      env?.POLLINATIONS_TOKEN ??
+      env?.VITE_POLLINATIONS_TOKEN ??
+      null;
+    if (candidate != null) {
+      const value = String(candidate).trim();
+      if (value) return value;
+    }
+  }
+  return null;
+}
+
 export async function onRequest(context) {
-  const token = context?.env?.POLLI_TOKEN ?? context?.env?.VITE_POLLI_TOKEN ?? null;
+  const token = readTokenFromEnvironment(context);
   if (!token) {
     return new Response(JSON.stringify({ error: 'Pollinations token is not configured.' }), {
       status: 404,

--- a/tests/polli-token-function-env.test.mjs
+++ b/tests/polli-token-function-env.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { onRequest } from '../.github/functions/polli-token.js';
+
+export const name = 'Pollinations token function reads secrets from multiple environments';
+
+export async function run() {
+  const originalToken = process.env.POLLI_TOKEN;
+  const originalViteToken = process.env.VITE_POLLI_TOKEN;
+
+  try {
+    delete process.env.VITE_POLLI_TOKEN;
+    process.env.POLLI_TOKEN = 'function-process-token';
+
+    const response = await onRequest({ env: {} });
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.deepEqual(payload, { token: 'function-process-token' });
+  } finally {
+    if (typeof originalToken === 'undefined') {
+      delete process.env.POLLI_TOKEN;
+    } else {
+      process.env.POLLI_TOKEN = originalToken;
+    }
+
+    if (typeof originalViteToken === 'undefined') {
+      delete process.env.VITE_POLLI_TOKEN;
+    } else {
+      process.env.VITE_POLLI_TOKEN = originalViteToken;
+    }
+  }
+}

--- a/tests/pollinations-token-env.test.mjs
+++ b/tests/pollinations-token-env.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { createPollinationsClient, __testing } from '../src/pollinations-client.js';
+
+export const name = 'Pollinations client resolves tokens from development environment variables';
+
+function createStubResponse(status = 404) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get() {
+        return null;
+      },
+    },
+    async json() {
+      return {};
+    },
+    async text() {
+      return '';
+    },
+  };
+}
+
+export async function run() {
+  const originalFetch = globalThis.fetch;
+  const originalToken = process.env.POLLI_TOKEN;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  try {
+    globalThis.fetch = async () => createStubResponse(404);
+    process.env.POLLI_TOKEN = 'process-env-token';
+    process.env.NODE_ENV = 'development';
+    __testing.resetTokenCache();
+
+    const { client, tokenSource } = await createPollinationsClient();
+    assert.equal(tokenSource, 'env');
+
+    const token = await client._auth.getToken();
+    assert.equal(token, 'process-env-token');
+  } finally {
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    } else {
+      delete globalThis.fetch;
+    }
+
+    if (typeof originalToken === 'undefined') {
+      delete process.env.POLLI_TOKEN;
+    } else {
+      process.env.POLLI_TOKEN = originalToken;
+    }
+
+    if (typeof originalNodeEnv === 'undefined') {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    __testing.resetTokenCache();
+  }
+}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   root: '.',
   base: './',
+  envPrefix: ['VITE_', 'POLLI_', 'POLLINATIONS_'],
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- ensure the Pages token endpoint reads Pollinations secrets from both Pages and process environments
- allow the client to resolve tokens from Vite and Node environments by broadening env detection and exposing POLLI_* prefixes
- add regression tests covering the serverless function and client env fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c9ec68b054832f88f13352c518a831