### PR TITLE
Allow running without Pollinations token

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,6 @@ expects the token to be provided at runtime so it is never bundled into the stat
   will capture the token, remove it from the visible URL, and apply it to subsequent Pollinations
   requests.
 
-If the token cannot be resolved the UI remains disabled and an error is shown in the status banner.
+If the token cannot be resolved the application continues without one so you can still browse public
+models. A warning is shown to indicate that gated Pollinations models will remain unavailable until a
+token is supplied.

--- a/README.md
+++ b/README.md
@@ -34,16 +34,19 @@ make sure the contents of `dist/` are deployed.
 ## Configuring the Pollinations token
 
 Pollinations models that require tiered access expect the token to be supplied as a request
-parameter. The demo resolves the token at runtime so secrets are never baked into the static assets.
+parameter. The demo can resolve the token at runtime (via URL parameters, meta tags, or injected
+globals) and also honours build-time environment variables when you want to bake the token into the
+bundle.
 
 - **GitHub Pages / production** – Provide the `POLLI_TOKEN` secret in the repository (or Pages
   environment). You can surface the token to the client by setting `window.__POLLINATIONS_TOKEN__`,
-  defining a `<meta name="pollinations-token" content="...">` tag, or adding a `token=...` query
-  parameter to the published URL (e.g. `https://example.github.io/chatdemo/?token=your-secret`). The
-  token is removed from the visible URL after it is captured.
+  defining a `<meta name="pollinations-token" content="...">` tag, adding a `token=...` query
+  parameter to the published URL (e.g. `https://example.github.io/chatdemo/?token=your-secret`), or
+  injecting `POLLI_TOKEN`/`VITE_POLLI_TOKEN` during the build so the token ships with the bundle.
+  The token is removed from the visible URL after it is captured.
 - **Local development** – Define `POLLI_TOKEN`/`VITE_POLLI_TOKEN` in your shell when running
   `npm run dev`, add a meta tag as above, or inject `window.__POLLINATIONS_TOKEN__` before the
-  application bootstraps.
+  application bootstraps. Build-time environment variables also work in development.
 - **Optional runtime endpoint** – If you expose the token via a custom endpoint, configure its URL
   with `POLLI_TOKEN_ENDPOINT`/`VITE_POLLI_TOKEN_ENDPOINT` (environment variables),
   `window.__POLLINATIONS_TOKEN_ENDPOINT__`, or a `<meta name="pollinations-token-endpoint" ...>` tag.
@@ -51,3 +54,6 @@ parameter. The demo resolves the token at runtime so secrets are never baked int
 
 If the token cannot be resolved the application continues without one, allowing you to browse public
 models while gated Pollinations models remain unavailable until a token is supplied.
+
+All chat and image requests automatically include a random eight-digit `seed` parameter so they
+match Pollinations' expected request format.

--- a/README.md
+++ b/README.md
@@ -33,20 +33,21 @@ make sure the contents of `dist/` are deployed.
 
 ## Configuring the Pollinations token
 
-Pollinations models that require tiered access need a token on every request. The application now
-expects the token to be provided at runtime so it is never bundled into the static assets.
+Pollinations models that require tiered access expect the token to be supplied as a request
+parameter. The demo resolves the token at runtime so secrets are never baked into the static assets.
 
 - **GitHub Pages / production** – Provide the `POLLI_TOKEN` secret in the repository (or Pages
-  environment). The included Pages Function at `.github/functions/polli-token.js` exposes the token
-  at runtime via `/api/polli-token`, and responses are marked as non-cacheable.
-- **Local development** – Either define `POLLI_TOKEN`/`VITE_POLLI_TOKEN` in your shell when running
-  `npm run dev`, add a `<meta name="pollinations-token" ...>` tag to `index.html`, or inject
-  `window.__POLLINATIONS_TOKEN__` before the application bootstraps.
-- **Static overrides** – When a dynamic endpoint is unavailable, append a `token` query parameter
-  to the page URL (e.g. `https://example.github.io/chatdemo/?token=your-secret`). The application
-  will capture the token, remove it from the visible URL, and apply it to subsequent Pollinations
-  requests.
+  environment). You can surface the token to the client by setting `window.__POLLINATIONS_TOKEN__`,
+  defining a `<meta name="pollinations-token" content="...">` tag, or adding a `token=...` query
+  parameter to the published URL (e.g. `https://example.github.io/chatdemo/?token=your-secret`). The
+  token is removed from the visible URL after it is captured.
+- **Local development** – Define `POLLI_TOKEN`/`VITE_POLLI_TOKEN` in your shell when running
+  `npm run dev`, add a meta tag as above, or inject `window.__POLLINATIONS_TOKEN__` before the
+  application bootstraps.
+- **Optional runtime endpoint** – If you expose the token via a custom endpoint, configure its URL
+  with `POLLI_TOKEN_ENDPOINT`/`VITE_POLLI_TOKEN_ENDPOINT` (environment variables),
+  `window.__POLLINATIONS_TOKEN_ENDPOINT__`, or a `<meta name="pollinations-token-endpoint" ...>` tag.
+  When present, the client will fetch the token from that endpoint.
 
-If the token cannot be resolved the application continues without one so you can still browse public
-models. A warning is shown to indicate that gated Pollinations models will remain unavailable until a
-token is supplied.
+If the token cannot be resolved the application continues without one, allowing you to browse public
+models while gated Pollinations models remain unavailable until a token is supplied.

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import {
   matchesModelIdentifier,
   normalizeTextCatalog,
 } from './model-catalog.js';
+import { generateSeed } from './seed.js';
 
 const FALLBACK_MODELS = [
   createFallbackModel('openai', 'OpenAI GPT-5 Nano (fallback)'),
@@ -443,6 +444,7 @@ async function handleChatResponse(initialResponse, model, endpoint) {
           messages: state.conversation,
           tools: [IMAGE_TOOL],
           tool_choice: 'auto',
+          seed: generateSeed(),
         },
         client,
       );
@@ -499,7 +501,7 @@ async function handleToolCalls(toolCalls) {
     const caption = String(args.caption ?? prompt).trim() || prompt;
 
     try {
-      const { dataUrl } = await generateImageAsset(prompt, {
+      const { dataUrl, seed } = await generateImageAsset(prompt, {
         width,
         height,
         model: args.model,
@@ -520,6 +522,7 @@ async function handleToolCalls(toolCalls) {
           prompt,
           width,
           height,
+          seed,
         }),
       });
     } catch (error) {
@@ -545,12 +548,14 @@ async function generateImageAsset(prompt, { width, height, model: imageModel } =
     if (!client) {
       throw new Error('Pollinations client is not ready.');
     }
+    const seed = generateSeed();
     const binary = await image(
       prompt,
       {
         width,
         height,
         model: imageModel,
+        seed,
         nologo: true,
         private: true,
         enhance: true,
@@ -559,7 +564,7 @@ async function generateImageAsset(prompt, { width, height, model: imageModel } =
     );
     const dataUrl = binary.toDataUrl();
     resetStatusIfIdle();
-    return { dataUrl };
+    return { dataUrl, seed };
   } catch (error) {
     console.error('Image generation failed', error);
     throw error;
@@ -770,6 +775,7 @@ async function requestChatCompletion(model, endpoints) {
   const attemptErrors = [];
   for (const endpoint of endpoints) {
     try {
+      const requestSeed = generateSeed();
       const response = await chat(
         {
           model: model.id,
@@ -777,6 +783,7 @@ async function requestChatCompletion(model, endpoints) {
           messages: state.conversation,
           tools: [IMAGE_TOOL],
           tool_choice: 'auto',
+          seed: requestSeed,
         },
         client,
       );
@@ -975,7 +982,7 @@ els.form.addEventListener('submit', async event => {
       if (!prompt) {
         throw new Error('Provide a prompt after /image');
       }
-      const { dataUrl } = await generateImageAsset(prompt);
+      const { dataUrl, seed } = await generateImageAsset(prompt);
       addMessage({
         role: 'assistant',
         type: 'image',
@@ -983,6 +990,7 @@ els.form.addEventListener('submit', async event => {
         alt: prompt,
         caption: prompt,
       });
+      console.info('Generated Pollinations image with seed %s.', seed);
       resetStatusIfIdle();
     } else {
       await sendPrompt(raw);

--- a/src/seed.js
+++ b/src/seed.js
@@ -1,0 +1,10 @@
+const MIN_SEED = 10_000_000;
+const MAX_SEED = 99_999_999;
+
+export function generateSeed(random = Math.random) {
+  const fn = typeof random === 'function' ? random : Math.random;
+  const value = fn();
+  const clamped = Number.isFinite(value) ? Math.max(0, Math.min(0.999999999999, value)) : 0;
+  const span = MAX_SEED - MIN_SEED + 1;
+  return Math.floor(clamped * span + MIN_SEED);
+}

--- a/tests/pollinations-token-optional.test.mjs
+++ b/tests/pollinations-token-optional.test.mjs
@@ -68,6 +68,8 @@ export async function run() {
     for (const key of endpointEnvKeys) {
       delete process.env[key];
     }
+    process.env.POLLI_TOKEN = 'undefined';
+    process.env.VITE_POLLI_TOKEN = 'null';
     delete process.env.NODE_ENV;
     delete globalThis.__POLLINATIONS_TOKEN_ENDPOINT__;
     delete globalThis.POLLI_TOKEN_ENDPOINT;

--- a/tests/pollinations-token-optional.test.mjs
+++ b/tests/pollinations-token-optional.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { createPollinationsClient, __testing } from '../src/pollinations-client.js';
+
+export const name = 'Pollinations client falls back to unauthenticated access when no token is available';
+
+function createStubResponse(status = 404) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get() {
+        return null;
+      },
+    },
+    async json() {
+      return {};
+    },
+    async text() {
+      return '';
+    },
+  };
+}
+
+export async function run() {
+  const originalFetch = globalThis.fetch;
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  const originalLocation = globalThis.location;
+  const originalHistory = globalThis.history;
+  const originalNodeEnv = process.env.NODE_ENV;
+  const envKeys = [
+    'POLLI_TOKEN',
+    'VITE_POLLI_TOKEN',
+    'POLLINATIONS_TOKEN',
+    'VITE_POLLINATIONS_TOKEN',
+  ];
+  const originalEnv = Object.fromEntries(envKeys.map(key => [key, process.env[key]]));
+
+  try {
+    globalThis.fetch = async () => createStubResponse(404);
+    delete globalThis.window;
+    delete globalThis.document;
+    delete globalThis.location;
+    delete globalThis.history;
+    for (const key of envKeys) {
+      delete process.env[key];
+    }
+    delete process.env.NODE_ENV;
+
+    __testing.resetTokenCache();
+
+    const { client, tokenSource, tokenMessages } = await createPollinationsClient();
+
+    assert.equal(tokenSource, null);
+    assert.equal(client.authMode, 'none');
+    assert.ok(Array.isArray(tokenMessages));
+    assert.ok(
+      tokenMessages.some(message => message && message.includes('Token endpoint not found')),
+      'tokenMessages should include the failed API attempt',
+    );
+  } finally {
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    } else {
+      delete globalThis.fetch;
+    }
+
+    if (typeof originalWindow === 'undefined') {
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+
+    if (typeof originalDocument === 'undefined') {
+      delete globalThis.document;
+    } else {
+      globalThis.document = originalDocument;
+    }
+
+    if (typeof originalLocation === 'undefined') {
+      delete globalThis.location;
+    } else {
+      globalThis.location = originalLocation;
+    }
+
+    if (typeof originalHistory === 'undefined') {
+      delete globalThis.history;
+    } else {
+      globalThis.history = originalHistory;
+    }
+
+    for (const key of envKeys) {
+      if (typeof originalEnv[key] === 'undefined') {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+
+    if (typeof originalNodeEnv === 'undefined') {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    __testing.resetTokenCache();
+  }
+}

--- a/tests/seed-generator.test.mjs
+++ b/tests/seed-generator.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { generateSeed } from '../src/seed.js';
+
+export const name = 'Seed generator produces eight-digit integers';
+
+export async function run() {
+  const minimum = generateSeed(() => 0);
+  const maximum = generateSeed(() => 0.999999999999);
+  const clampHigh = generateSeed(() => 1.5);
+  const clampLow = generateSeed(() => -0.5);
+  const mid = generateSeed(() => 0.42);
+
+  for (const value of [minimum, maximum, clampHigh, clampLow, mid]) {
+    assert(Number.isInteger(value), `Seed should be an integer (received ${value})`);
+    assert(value >= 10_000_000 && value <= 99_999_999, `Seed ${value} must be eight digits`);
+    assert.equal(String(value).length, 8, `Seed ${value} should contain exactly eight digits`);
+  }
+
+  assert.equal(minimum, 10_000_000);
+  assert.equal(maximum, 99_999_999);
+  assert.equal(clampHigh, 99_999_999);
+  assert.equal(clampLow, 10_000_000);
+}


### PR DESCRIPTION
## Summary
- allow the Pollinations client to fall back to unauthenticated mode while tracking token resolution attempts
- surface a non-blocking status message when no token is configured and update the README guidance
- add regression coverage to ensure unauthenticated access remains available when the token endpoint is absent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68caa2aae908832f9556c7b6591f7142