### PR TITLE
Propagate Pollinations token secrets into CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,11 @@ jobs:
   build:
     name: Build and Upload Artifacts
     runs-on: ubuntu-latest
+    env:
+      POLLI_TOKEN: ${{ coalesce(secrets.POLLI_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLINATIONS_TOKEN) }}
+      VITE_POLLI_TOKEN: ${{ coalesce(secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN) }}
+      POLLINATIONS_TOKEN: ${{ coalesce(secrets.POLLINATIONS_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN) }}
+      VITE_POLLINATIONS_TOKEN: ${{ coalesce(secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -53,6 +58,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     continue-on-error: true
+    env:
+      POLLI_TOKEN: ${{ coalesce(secrets.POLLI_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLINATIONS_TOKEN) }}
+      VITE_POLLI_TOKEN: ${{ coalesce(secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN) }}
+      POLLINATIONS_TOKEN: ${{ coalesce(secrets.POLLINATIONS_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN) }}
+      VITE_POLLINATIONS_TOKEN: ${{ coalesce(secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,6 +14,11 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      POLLI_TOKEN: ${{ coalesce(secrets.POLLI_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLINATIONS_TOKEN) }}
+      VITE_POLLI_TOKEN: ${{ coalesce(secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN) }}
+      POLLINATIONS_TOKEN: ${{ coalesce(secrets.POLLINATIONS_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN) }}
+      VITE_POLLINATIONS_TOKEN: ${{ coalesce(secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- expose Pollinations token secrets to the main branch build and test jobs so the Vite build can read them
- mirror the same secret propagation in the pull request test workflow to keep checks aligned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cae66ecf48832fb5bdc8ed9de342be