### PR TITLE
Fix workflow secret fallbacks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     name: Build and Upload Artifacts
     runs-on: ubuntu-latest
     env:
-      POLLI_TOKEN: ${{ coalesce(secrets.POLLI_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLINATIONS_TOKEN) }}
-      VITE_POLLI_TOKEN: ${{ coalesce(secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN) }}
-      POLLINATIONS_TOKEN: ${{ coalesce(secrets.POLLINATIONS_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN) }}
-      VITE_POLLINATIONS_TOKEN: ${{ coalesce(secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN) }}
+      POLLI_TOKEN: ${{ secrets.POLLI_TOKEN || secrets.VITE_POLLI_TOKEN || secrets.POLLINATIONS_TOKEN || secrets.VITE_POLLINATIONS_TOKEN }}
+      VITE_POLLI_TOKEN: ${{ secrets.VITE_POLLI_TOKEN || secrets.POLLI_TOKEN || secrets.VITE_POLLINATIONS_TOKEN || secrets.POLLINATIONS_TOKEN }}
+      POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN || secrets.POLLI_TOKEN || secrets.VITE_POLLINATIONS_TOKEN || secrets.VITE_POLLI_TOKEN }}
+      VITE_POLLINATIONS_TOKEN: ${{ secrets.VITE_POLLINATIONS_TOKEN || secrets.POLLINATIONS_TOKEN || secrets.VITE_POLLI_TOKEN || secrets.POLLI_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,10 +59,10 @@ jobs:
     needs: build
     continue-on-error: true
     env:
-      POLLI_TOKEN: ${{ coalesce(secrets.POLLI_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLINATIONS_TOKEN) }}
-      VITE_POLLI_TOKEN: ${{ coalesce(secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN) }}
-      POLLINATIONS_TOKEN: ${{ coalesce(secrets.POLLINATIONS_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN) }}
-      VITE_POLLINATIONS_TOKEN: ${{ coalesce(secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN) }}
+      POLLI_TOKEN: ${{ secrets.POLLI_TOKEN || secrets.VITE_POLLI_TOKEN || secrets.POLLINATIONS_TOKEN || secrets.VITE_POLLINATIONS_TOKEN }}
+      VITE_POLLI_TOKEN: ${{ secrets.VITE_POLLI_TOKEN || secrets.POLLI_TOKEN || secrets.VITE_POLLINATIONS_TOKEN || secrets.POLLINATIONS_TOKEN }}
+      POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN || secrets.POLLI_TOKEN || secrets.VITE_POLLINATIONS_TOKEN || secrets.VITE_POLLI_TOKEN }}
+      VITE_POLLINATIONS_TOKEN: ${{ secrets.VITE_POLLINATIONS_TOKEN || secrets.POLLINATIONS_TOKEN || secrets.VITE_POLLI_TOKEN || secrets.POLLI_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     env:
-      POLLI_TOKEN: ${{ coalesce(secrets.POLLI_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLINATIONS_TOKEN) }}
-      VITE_POLLI_TOKEN: ${{ coalesce(secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN) }}
-      POLLINATIONS_TOKEN: ${{ coalesce(secrets.POLLINATIONS_TOKEN, secrets.POLLI_TOKEN, secrets.VITE_POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN) }}
-      VITE_POLLINATIONS_TOKEN: ${{ coalesce(secrets.VITE_POLLINATIONS_TOKEN, secrets.POLLINATIONS_TOKEN, secrets.VITE_POLLI_TOKEN, secrets.POLLI_TOKEN) }}
+      POLLI_TOKEN: ${{ secrets.POLLI_TOKEN || secrets.VITE_POLLI_TOKEN || secrets.POLLINATIONS_TOKEN || secrets.VITE_POLLINATIONS_TOKEN }}
+      VITE_POLLI_TOKEN: ${{ secrets.VITE_POLLI_TOKEN || secrets.POLLI_TOKEN || secrets.VITE_POLLINATIONS_TOKEN || secrets.POLLINATIONS_TOKEN }}
+      POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN || secrets.POLLI_TOKEN || secrets.VITE_POLLINATIONS_TOKEN || secrets.VITE_POLLI_TOKEN }}
+      VITE_POLLINATIONS_TOKEN: ${{ secrets.VITE_POLLINATIONS_TOKEN || secrets.POLLINATIONS_TOKEN || secrets.VITE_POLLI_TOKEN || secrets.POLLI_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- replace the unsupported `coalesce` expressions in the CI workflows with logical OR fallbacks for Pollinations secrets
- ensure each job still receives whichever Pollinations token secret is defined

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cae76ccf2c832fbc435c2c1f1e5b9c