### PR TITLE
Improve TTS chunk sequencing

### DIFF
--- a/tests/tts-chunker.test.mjs
+++ b/tests/tts-chunker.test.mjs
@@ -1,15 +1,21 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
-export const name = 'TTS chunker: halved payload (500 char cap) wired in call site';
+export const name = 'TTS chunker: halved payload (250 char cap) wired in call site';
 
 export async function run() {
   const js = await readFile(new URL('../src/main.js', import.meta.url), 'utf8');
-  const defMatch = js.match(/function\s+buildTtsChunks\s*\(text,\s*\{\s*maxChars\s*=\s*(\d+)\s*\}\s*=\s*\{\}\)\s*\{/);
-  const defaultMax = defMatch ? Number(defMatch[1]) : null;
-  assert.equal(defaultMax, 500, 'default maxChars must be 500');
+  const constMatch = js.match(/const\s+TTS_CHUNK_MAX_CHARS\s*=\s*(\d+)\s*;/);
+  const constantValue = constMatch ? Number(constMatch[1]) : null;
+  assert.equal(constantValue, 250, 'TTS chunk limit constant must be 250 characters');
 
-  const callMatch = js.match(/buildTtsChunks\(raw,\s*\{\s*maxChars:\s*(\d+)\s*\}\s*\)/);
-  const callMax = callMatch ? Number(callMatch[1]) : null;
-  assert.equal(callMax, 500, 'startVoicePlaybackForMessage should request 500-char chunks');
+  assert.ok(
+    /function\s+buildTtsChunks\s*\(text,\s*\{\s*maxChars\s*=\s*TTS_CHUNK_MAX_CHARS\s*\}\s*=\s*\{\}\)\s*\{/.test(js),
+    'buildTtsChunks should default to TTS_CHUNK_MAX_CHARS',
+  );
+
+  assert.ok(
+    /buildTtsChunks\(raw,\s*\{\s*maxChars:\s*TTS_CHUNK_MAX_CHARS\s*\}\s*\)/.test(js),
+    'startVoicePlaybackForMessage should request TTS_CHUNK_MAX_CHARS-sized chunks',
+  );
 }


### PR DESCRIPTION
## Summary
- halve Pollinations TTS chunk size by introducing a shared constant and using it for chunk building
- prevent overlapping playback by tracking the active chunk until its audio fully completes
- update the TTS chunker regression test to reflect the new constant-based wiring

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d0c22ade94832fa47482e40cca06cc