### PR TITLE
Enforce Pollinations request pacing with retries

### DIFF
--- a/Libs/pollilib/python/polliLib/images.py
+++ b/Libs/pollilib/python/polliLib/images.py
@@ -45,17 +45,37 @@ class ImageMixin:
 
         url = self._image_prompt_url(prompt)
         eff_timeout = timeout if timeout is not None else max(self.timeout, 60.0)
+        attempt = 0
+        stream = bool(out_path)
+        response = None
+        while True:
+            with self._request_lock:
+                self._wait_before_attempt(attempt)
+                resp = self.session.get(url, params=params, timeout=eff_timeout, stream=stream)
+                if self._should_retry_status(resp.status_code):
+                    if not self._can_retry(attempt + 1):
+                        resp.raise_for_status()
+                    resp.close()
+                    attempt += 1
+                    continue
+                try:
+                    resp.raise_for_status()
+                except Exception:
+                    resp.close()
+                    raise
+                self._mark_success()
+                response = resp
+                break
         if out_path:
-            with self.session.get(url, params=params, timeout=eff_timeout, stream=True) as r:
-                r.raise_for_status()
+            with response as r:
                 with open(out_path, "wb") as f:
                     for chunk in r.iter_content(chunk_size=chunk_size):
                         if chunk:
                             f.write(chunk)
             return out_path
-        resp = self.session.get(url, params=params, timeout=eff_timeout)
-        resp.raise_for_status()
-        return resp.content
+        content = response.content
+        response.close()
+        return content
 
     def save_image_timestamped(
         self,
@@ -112,15 +132,35 @@ class ImageMixin:
             params["referrer"] = referrer
         if token:
             params["token"] = token
+        attempt = 0
+        stream = bool(out_path)
+        response = None
+        while True:
+            with self._request_lock:
+                self._wait_before_attempt(attempt)
+                resp = self.session.get(image_url, params=params, timeout=timeout or self.timeout, stream=stream)
+                if self._should_retry_status(resp.status_code):
+                    if not self._can_retry(attempt + 1):
+                        resp.raise_for_status()
+                    resp.close()
+                    attempt += 1
+                    continue
+                try:
+                    resp.raise_for_status()
+                except Exception:
+                    resp.close()
+                    raise
+                self._mark_success()
+                response = resp
+                break
         if out_path:
-            with self.session.get(image_url, params=params, timeout=timeout or self.timeout, stream=True) as r:
-                r.raise_for_status()
+            with response as r:
                 with open(out_path, "wb") as f:
                     for chunk in r.iter_content(chunk_size=chunk_size):
                         if chunk:
                             f.write(chunk)
             return out_path
-        resp = self.session.get(image_url, params=params, timeout=timeout or self.timeout)
-        resp.raise_for_status()
-        return resp.content
+        content = response.content
+        response.close()
+        return content
 

--- a/Libs/pollilib/python/tests/conftest.py
+++ b/Libs/pollilib/python/tests/conftest.py
@@ -50,6 +50,10 @@ class FakeResponse:
 
     def __exit__(self, exc_type, exc, tb):
         self._closed = True
+        return False
+
+    def close(self):
+        self._closed = True
 
 
 class FakeSession:

--- a/docs/APIDOCS.md
+++ b/docs/APIDOCS.md
@@ -19,6 +19,7 @@ Click the links below to see examples in your browser:
 - [Pollinations.AI API Documentation](#pollinationsai-api-documentation)
   - [Quickstart](#quickstart)
   - [Summary / Navigation](#summary--navigation)
+  - [Request Pacing & Backoff ⏱️](#request-pacing--backoff-️)
   - [Generate Image API 🖼️](#generate-image-api-️)
     - [1. Text-To-Image (GET) 🖌️](#1-text-to-image-get-️)
     - [2. List Available Image Models 📜](#2-list-available-image-models-)
@@ -36,6 +37,16 @@ Click the links below to see examples in your browser:
   - [Authentication & Tiers 🔑](#authentication--tiers-)
   - [License 📜](#license-)
 ---
+
+# Request Pacing & Backoff ⏱️
+
+Pollinations enforces a minimum spacing between generation requests, especially on the Flower tier that powers this project. To avoid rate-limit walls:
+
+- Leave at least **3 seconds between successful calls** to the text, image, or audio generation endpoints.
+- When a request is rate-limited (HTTP 429/503) you can retry sooner, starting at **500 ms** and increasing by **100 ms** per attempt up to **4 seconds**.
+- PolliLib (our JavaScript and Python clients) now performs this pacing automatically: it queues generation requests, guarantees the 3-second post-success gap, and performs the short incremental backoff on retryable errors.
+
+If you are calling the HTTP APIs directly, adopt the same pattern to stay within the Flower tier guardrails and to minimize hard failures.
 
 # Generate Image API 🖼️
 


### PR DESCRIPTION
## Summary
- add centralized rate limiting and incremental backoff to the PolliLib base client for text, image, and audio generation
- update JavaScript and Python mixins plus tests to cover the new pacing behaviour
- document Flower tier request spacing and retry rules in the Pollinations API guide

## Testing
- npm test -- --runInBand
- pytest Libs/pollilib/python/tests


------
https://chatgpt.com/codex/tasks/task_b_68d44ac5d5dc832fa416cefacbb34ea9